### PR TITLE
Grab window when snapshot button pressed

### DIFF
--- a/src/main/java/qupath/ext/snapshots/ui/SnapshotController.java
+++ b/src/main/java/qupath/ext/snapshots/ui/SnapshotController.java
@@ -125,6 +125,9 @@ public class SnapshotController extends BorderPane {
     private CheckBox cbCopyToClipboard;
 
     @FXML
+    private CheckBox cbDelayWindow;
+
+    @FXML
     private ComboBox<Format> comboFormat;
 
     @FXML
@@ -328,10 +331,11 @@ public class SnapshotController extends BorderPane {
             processing.set(true);
             var window = getScene().getWindow();
             window.setOpacity(0.0);
-            var winToSnapshot = focusedWindow.getValue();
+            Window winToSnapshot = cbDelayWindow.isSelected() ? focusedWindow.getValue() : null;
             CompletableFuture.delayedExecutor(delay, TimeUnit.SECONDS, Platform::runLater)
                     .execute(() -> {
-                        snapshotWindow(winToSnapshot, file, doScreenshot);
+                        var win = winToSnapshot == null ? focusedWindow.getValue() : winToSnapshot;
+                        snapshotWindow(win, file, doScreenshot);
                         processing.set(false);
                         window.setOpacity(1.0);
                     });
@@ -406,15 +410,15 @@ public class SnapshotController extends BorderPane {
                         ImageIO.write(img, format.getFormatName(), file);
                 }
                 Dialogs.showInfoNotification(
-                        resources.getString("screenshot"),
-                        MessageFormat.format(resources.getString("screenshot.writtenTo"), file.getAbsolutePath())
+                        resources.getString("snapshot"),
+                        MessageFormat.format(resources.getString("snapshot.writtenTo"), file.getAbsolutePath())
                 );
             } catch (IOException e) {
                 Dialogs.showErrorMessage(
-                        resources.getString("screenshot.error"),
-                        MessageFormat.format(resources.getString("screenshot.unableToWrite"), file.getAbsolutePath())
+                        resources.getString("snapshot.error"),
+                        MessageFormat.format(resources.getString("snapshot.unableToWrite"), file.getAbsolutePath())
                 );
-                logger.error("Unable to take screenshot of current window", e);
+                logger.error("Unable to take snapshot of current window", e);
             }
         }
     }

--- a/src/main/resources/qupath/ext/snapshots/ui/snapshot-controller.fxml
+++ b/src/main/resources/qupath/ext/snapshots/ui/snapshot-controller.fxml
@@ -47,6 +47,7 @@
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             <RowConstraints vgrow="SOMETIMES" />
         </rowConstraints>
          <children>
@@ -85,8 +86,8 @@
                <tooltip>
                   <Tooltip text="%format.description" />
                </tooltip></ComboBox>
-            <Label text="%window.label" GridPane.rowIndex="7" />
-            <Label fx:id="labelCurrentWindow" maxWidth="1.7976931348623157E308" style="-fx-font-weight: bold;" text="Label" GridPane.columnIndex="1" GridPane.rowIndex="7">
+            <Label text="%window.label" GridPane.rowIndex="8" />
+            <Label fx:id="labelCurrentWindow" maxWidth="1.7976931348623157E308" style="-fx-font-weight: bold;" text="Label" GridPane.columnIndex="1" GridPane.rowIndex="8">
                <tooltip>
                   <Tooltip text="%window.description" />
                </tooltip></Label>
@@ -99,12 +100,17 @@
                <tooltip>
                   <Tooltip text="%scale.description" />
                </tooltip></Spinner>
-            <ProgressBar fx:id="progressDelay" maxHeight="12.0" maxWidth="1.7976931348623157E308" visible="false" GridPane.columnSpan="2147483647" GridPane.rowIndex="8" />
-            <Button fx:id="btnSize" mnemonicParsing="false" onAction="#promptToSetSize" text="%size.label" GridPane.columnIndex="2" GridPane.rowIndex="7">
+            <ProgressBar fx:id="progressDelay" maxHeight="12.0" maxWidth="1.7976931348623157E308" visible="false" GridPane.columnSpan="2147483647" GridPane.rowIndex="9" />
+            <Button fx:id="btnSize" mnemonicParsing="false" onAction="#promptToSetSize" text="%size.label" GridPane.columnIndex="2" GridPane.rowIndex="8">
                <tooltip>
                   <Tooltip text="%size.description" />
                </tooltip>
             </Button>
+            <CheckBox fx:id="cbDelayWindow" mnemonicParsing="false" text="%delay.window.label" GridPane.columnSpan="2147483647" GridPane.rowIndex="7">
+               <tooltip>
+                  <Tooltip text="%delay.window.description" />
+               </tooltip>
+            </CheckBox>
          </children>
          <padding>
             <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />

--- a/src/main/resources/qupath/ext/snapshots/ui/strings.properties
+++ b/src/main/resources/qupath/ext/snapshots/ui/strings.properties
@@ -3,7 +3,7 @@ title = Snapshot extension
 name = QuPath snapshot extension
 description = Extension to help with generating QuPath snapshots & screenshots (e.g. to make training material)
 
-stage.title = Screenshot helper
+stage.title = Snapshot helper
 
 error = Snapshot extension error
 error.gui-loading-failed = GUI loading failed
@@ -29,6 +29,10 @@ format.description = Choose the image file format for saving. Ignored if the nam
 delay.label = Delay (seconds)
 delay.description = Wait the specified number of seconds before making the screenshot or snapshot
 
+delay.window.label = Use window active before delay
+delay.window.description = Snapshot the window that is active before the delay.\n\
+  The alternative is to snapshot the current window, after the delay (required to snapshot modal dialogs).
+
 scale.label = Scale snapshot
 scale.description = Optionally generate a higher or lower resolution snapshot (no effect for screenshots)
 
@@ -48,7 +52,7 @@ width.description = Specify the width of the window
 height = Height
 height.description = Specify the height of the window
 
-screenshot = Screenshot
-screenshot.writtenTo = Written to {0}
-screenshot.error = Screenshot error
-screenshot.unableToWrite = Unable to write to {0}
+snapshot = Screenshot
+snapshot.writtenTo = Written to {0}
+snapshot.error = Screenshot error
+snapshot.unableToWrite = Unable to write to {0}


### PR DESCRIPTION
This fixes a bug in delayed snapshots, where the current window was identified at the point the snapshot was created - not at the point the snapshot was requested.

This meant that it wasn't possible to create a screenshot that showed the full QuPath window while interacting with any other window - since only the 'other window' would end up being captured.